### PR TITLE
Improve documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Grype for Visual Studio Code
+
+If you are looking to contribute to this project and want to open a GitHub pull request ("PR"), there are a few guidelines of what we are looking for in patches. Make sure you go through this document and ensure that your code proposal is aligned.
+
+## Sign off your work
+
+The `sign-off` is an added line at the end of the explanation for the commit, certifying that you wrote it or otherwise have the right to submit it as an open-source patch. By submitting a contribution, you agree to be bound by the terms of the DCO Version 1.1 and Apache License Version 2.0.
+
+Signing off a commit certifies the below Developer's Certificate of Origin (DCO):
+
+```text
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+   (a) The contribution was created in whole or in part by me and I
+       have the right to submit it under the open source license
+       indicated in the file; or
+
+   (b) The contribution is based upon previous work that, to the best
+       of my knowledge, is covered under an appropriate open source
+       license and I have the right under that license to submit that
+       work with modifications, whether created in whole or in part
+       by me, under the same open source license (unless I am
+       permitted to submit under a different license), as indicated
+       in the file; or
+
+   (c) The contribution was provided directly to me by some other
+       person who certified (a), (b) or (c) and I have not modified
+       it.
+
+   (d) I understand and agree that this project and the contribution
+       are public and that a record of the contribution (including all
+       personal information I submit with it, including my sign-off) is
+       maintained indefinitely and may be redistributed consistent with
+       this project or the open source license(s) involved.
+```
+
+All contributions to this project are licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/).
+
+When committing your change, you can add the required line manually so that it looks like this:
+
+```text
+Signed-off-by: John Doe <john.doe@example.com>
+```
+
+Alternatively, configure your Git client with your name and email to use the `-s` flag when creating a commit:
+
+```text
+$ git config --global user.name "John Doe"
+$ git config --global user.email "john.doe@example.com"
+```
+
+Creating a signed-off commit is then possible with `-s` or `--signoff`:
+
+```text
+$ git commit -s -m "this is a commit message"
+```
+
+To double-check that the commit was signed-off, look at the log output:
+
+```text
+$ git log -1
+commit 37ceh170e4hb283bb73d958f2036ee5k07e7fde7 (HEAD -> issue-35, origin/main, main)
+Author: John Doe <john.doe@example.com>
+Date:   Mon Aug 1 11:27:13 2020 -0400
+
+    this is a commit message
+
+    Signed-off-by: John Doe <john.doe@example.com>
+```
+
+[//]: # "TODO: Commit guidelines, granular commits"
+[//]: # "TODO: Commit guidelines, descriptive messages"
+[//]: # "TODO: Commit guidelines, commit title, extra body description"
+[//]: # "TODO: PR title and description"
+
+## Sign your commits
+
+To ensure the authenticity and integrity of code contributions, **we require that all commits are signed**. Signing commits proves that your commits were truly created by you, as the holder of a private key.
+
+Configuring git to sign your commits is a straightforward process. To get set up, see [GitHub's documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
+## Test your changes
+
+This project has a `Makefile` which includes many helpers running both unit and integration tests. Although PRs will have automatic checks for these, it is useful to run them locally, ensuring they pass before submitting changes. Ensure you've bootstrapped once before running tests:
+
+```text
+$ make bootstrap
+```
+
+You only need to bootstrap once. After the bootstrap process, you can run the tests as many times as needed:
+
+```text
+$ make unit
+$ make integration
+```
+
+## Document your changes
+
+When proposed changes are modifying user-facing functionality or output, it is expected the PR will include updates to the documentation as well.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,18 +83,10 @@ Configuring git to sign your commits is a straightforward process. To get set up
 
 ## Test your changes
 
-This project has a `Makefile` which includes many helpers running both unit and integration tests. Although PRs will have automatic checks for these, it is useful to run them locally, ensuring they pass before submitting changes. Ensure you've bootstrapped once before running tests:
+Ensure that your changes have passed the test suite. To run this project's tests, using the following commands:
 
-```text
-$ make bootstrap
-```
-
-You only need to bootstrap once. After the bootstrap process, you can run the tests as many times as needed:
-
-```text
-$ make unit
-$ make integration
-```
+- `npm test-unit`
+- `npm test-integration`
 
 ## Document your changes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Grype for Visual Studio Code
 
-The Grype extension makes it easy to know when your project is using dependencies that have known security vulnerabilities.
+[![GitHub release](https://img.shields.io/github/release/anchore/grype-vscode.svg)](https://github.com/anchore/grype-vscode/releases/latest)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/grype-vscode/blob/main/LICENSE)
+[![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack)](https://anchore.com/slack)
+
+The Grype extension for Visual Studio Code makes it easy to know when your project is using dependencies that have known security vulnerabilities.
 
 ![Grype Extension Demo](https://user-images.githubusercontent.com/5199289/92470955-29b75500-f1a5-11ea-82f6-941c9a6934f8.gif)
 


### PR DESCRIPTION
This PR improves grype-vscode's documentation in the following ways:

1. Adds markdown badges to the `README.md`
2. Adds a `CONTRIBUTING.md`
