### PR TITLE
update actions so PR will build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
-on: [push]
+on: # rebuild any PRs and main branch changes
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
+      - edited
 
 jobs:
   build:


### PR DESCRIPTION
This action update allows workflows to run on PR made against the main branch

It will also run the CI workflow on creation and edits for releases

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>